### PR TITLE
Propagate general status for all build-in BT nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ site/*
 /.idea/
 /cmake-build-debug/
 /debs/
+.cache

--- a/include/behaviortree_cpp_v3/behavior_tree.h
+++ b/include/behaviortree_cpp_v3/behavior_tree.h
@@ -96,7 +96,14 @@ inline NodeType getType()
  *
  * @param root_node
  */
-general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* node);
+general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* root_node);
+
+/**
+ * @brief resetTreeGeneralStatus can be used to reset the general status of all nodes in the tree
+ *
+ * @param root_node
+ */
+void resetTreeGeneralStatus(TreeNode* root_node);
 
 /**
  * Debug function to print the hierarchy of the general status. Prints to std::cout by default.

--- a/include/behaviortree_cpp_v3/behavior_tree.h
+++ b/include/behaviortree_cpp_v3/behavior_tree.h
@@ -93,6 +93,8 @@ inline NodeType getType()
 
 /**
  * @brief buildTreeGeneralStatus can be used to create a general status message containing all ticked nodes
+ * This function can be used to collect the general status using standalone nodes.
+ * When using BT::Tree, this function is automatically called when BT::Tree is finishing and general_status contains already full information
  *
  * @param root_node
  */
@@ -100,6 +102,7 @@ general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* root_node);
 
 /**
  * @brief resetTreeGeneralStatus can be used to reset the general status of all nodes in the tree
+ *
  *
  * @param root_node
  */

--- a/include/behaviortree_cpp_v3/bt_factory.h
+++ b/include/behaviortree_cpp_v3/bt_factory.h
@@ -240,9 +240,13 @@ public:
 
   void updateGeneralStatus()
   {
-    if (rootNode() && rootNode()->getGeneralStatus().has_value())
+    if (rootNode())
     {
-      general_status = buildTreeGeneralStatus(rootNode());
+      if (rootNode()->getGeneralStatus().has_value())
+      {
+        general_status = buildTreeGeneralStatus(rootNode());
+      }
+      resetTreeGeneralStatus(rootNode());
     }
   }
 

--- a/include/behaviortree_cpp_v3/control_node.h
+++ b/include/behaviortree_cpp_v3/control_node.h
@@ -58,5 +58,8 @@ public:
   /// Set the status of all children to IDLE.
   /// also send a halt() signal to all RUNNING children
   void resetChildren();
+
+protected:
+  void propagateGeneralStatusFromFailingChild(const TreeNode* failing_child);
 };
 }   // namespace BT

--- a/include/behaviortree_cpp_v3/controls/switch_node.h
+++ b/include/behaviortree_cpp_v3/controls/switch_node.h
@@ -122,6 +122,12 @@ inline NodeStatus SwitchNode<NUM_CASES>::tick()
     resetChildren();
     running_child_ = -1;
   }
+
+  if (ret == NodeStatus::FAILURE)
+  {
+    propagateGeneralStatusFromFailingChild(children_nodes_[match_index]);
+  }
+  
   return ret;
 }
 

--- a/include/behaviortree_cpp_v3/decorators/consume_queue.h
+++ b/include/behaviortree_cpp_v3/decorators/consume_queue.h
@@ -74,6 +74,10 @@ public:
         }
         else
         {
+          if (child_state == NodeStatus::SUCCESS)
+          {
+            appendChildGeneralStatus(child_node_->getGeneralStatus());
+          }
           haltChild();
           if (child_state == NodeStatus::FAILURE)
           {

--- a/include/behaviortree_cpp_v3/decorators/keep_running_until_failure_node.h
+++ b/include/behaviortree_cpp_v3/decorators/keep_running_until_failure_node.h
@@ -47,6 +47,7 @@ inline NodeStatus KeepRunningUntilFailureNode::tick()
       return NodeStatus::FAILURE;
     }
     case NodeStatus::SUCCESS: {
+      appendChildGeneralStatus(child_node_->getGeneralStatus());
       resetChild();
       return NodeStatus::RUNNING;
     }

--- a/include/behaviortree_cpp_v3/status/general_status_interface.h
+++ b/include/behaviortree_cpp_v3/status/general_status_interface.h
@@ -21,6 +21,7 @@ enum BtErrorCodes : EnumType
 {
   OK = 0,
   BEHAVIOR_TREE_NODE_FAILURE = 2000000,
+  BEHAVIOR_TREE_PARALLEL_NODE_MULTIPLE_FAILURES = 2000001,
 };
 
 struct Timestamp

--- a/include/behaviortree_cpp_v3/status/general_status_interface.h
+++ b/include/behaviortree_cpp_v3/status/general_status_interface.h
@@ -17,6 +17,12 @@ namespace general_status
 {
 using EnumType = int;
 
+enum BtErrorCodes : EnumType
+{
+  OK = 0,
+  BEHAVIOR_TREE_NODE_FAILURE = 2000000,
+};
+
 struct Timestamp
 {
   int64_t seconds_;
@@ -44,7 +50,7 @@ struct GeneralStatus
 {
   uint64_t id_;
   Timestamp timestamp_;
-  EnumType status_code_;
+  EnumType status_code_ = BtErrorCodes::OK;
   Optional<EnumType> source_;
   Optional<ShuttleHardwareInfo> shuttle_hardware_info_;
   Optional<TaskInfo> task_info_;
@@ -60,7 +66,7 @@ struct GeneralStatus
   GeneralStatus(GeneralStatus&&) = default;
   GeneralStatus& operator=(GeneralStatus&&) = default;
 
-  GeneralStatus getCopy() const
+  GeneralStatus getShallowCopy() const
   {
     GeneralStatus copy;
     copy.id_ = id_;
@@ -72,13 +78,33 @@ struct GeneralStatus
     copy.opt_string_ = opt_string_;
     copy.shuttle_id_ = shuttle_id_;
     copy.station_name_ = station_name_;
+    copy.uuid_ = uuid_;
+    return copy;
+  }
+
+  GeneralStatus getCopy() const
+  {
+    auto copy = getShallowCopy();
     for (const auto& status : underlying_status_messages_)
     {
       copy.underlying_status_messages_.push_back(
           std::make_unique<GeneralStatus>(status->getCopy()));
     }
-    copy.uuid_ = uuid_;
     return copy;
+  }
+
+  void mergeDataShallow(const GeneralStatus& other)
+  {
+    id_ = other.id_;
+    timestamp_ = other.timestamp_;
+    status_code_ = other.status_code_;
+    source_ = other.source_;
+    shuttle_hardware_info_ = other.shuttle_hardware_info_;
+    task_info_ = other.task_info_;
+    opt_string_ = other.opt_string_;
+    shuttle_id_ = other.shuttle_id_;
+    station_name_ = other.station_name_;
+    uuid_ = other.uuid_;
   }
 };
 

--- a/include/behaviortree_cpp_v3/tree_node.h
+++ b/include/behaviortree_cpp_v3/tree_node.h
@@ -227,6 +227,8 @@ protected:
   void appendChildGeneralStatus(const Optional<general_status::GeneralStatus>& status);
 
   Optional<general_status::GeneralStatus> general_status_;
+  
+  GeneralStatusUpdateCallback general_status_update_callback_;
 
 private:  
   const std::string name_;
@@ -250,8 +252,6 @@ private:
   PostTickOverrideCallback post_condition_callback_;
 
   std::shared_ptr<WakeUpSignal> wake_up_;
-
-  GeneralStatusUpdateCallback general_status_update_callback_;
 };
 
 //-------------------------------------------------------

--- a/include/behaviortree_cpp_v3/tree_node.h
+++ b/include/behaviortree_cpp_v3/tree_node.h
@@ -100,8 +100,8 @@ public:
       std::function<Optional<NodeStatus>(TreeNode&, NodeStatus)>;
   using PostTickOverrideCallback =
       std::function<Optional<NodeStatus>(TreeNode&, NodeStatus, NodeStatus)>;
-  using GeneralStatusUpdateCallback =
-      std::function<Optional<general_status::GeneralStatus>(TreeNode&, NodeStatus)>;
+  using GeneralStatusUpdateCallback = std::function<void(
+      TreeNode&, NodeStatus, Optional<general_status::GeneralStatus>&)>;
 
   /**
      * @brief subscribeToStatusChange is used to attach a callback to a status change.
@@ -218,7 +218,13 @@ protected:
   /// Equivalent to setStatus(NodeStatus::IDLE)
   void resetStatus();
 
-  static GeneralStatusUpdateCallback getDefaultGeneralStatusUpdateCallback();
+  static void
+  defaultGeneralStatusUpdateCallback(TreeNode& tree_node, NodeStatus node_status,
+                                     Optional<general_status::GeneralStatus>& status);
+
+  void appendChildGeneralStatus(const Optional<general_status::GeneralStatus>& status);
+
+  Optional<general_status::GeneralStatus> general_status_;
 
 private:
   const std::string name_;
@@ -242,8 +248,6 @@ private:
   PostTickOverrideCallback post_condition_callback_;
 
   std::shared_ptr<WakeUpSignal> wake_up_;
-
-  Optional<general_status::GeneralStatus> general_status_;
 
   GeneralStatusUpdateCallback general_status_update_callback_;
 };

--- a/include/behaviortree_cpp_v3/tree_node.h
+++ b/include/behaviortree_cpp_v3/tree_node.h
@@ -196,8 +196,12 @@ public:
   void setGeneralStatusUpdateFunction(GeneralStatusUpdateCallback callback);
 
   const Optional<general_status::GeneralStatus>& getGeneralStatus() const;
-  
+
   void resetGeneralStatus();
+
+  static void
+  defaultGeneralStatusUpdateCallback(TreeNode& tree_node, NodeStatus node_status,
+                                     Optional<general_status::GeneralStatus>& status);
 
 protected:
   /// Method to be implemented by the user
@@ -220,17 +224,13 @@ protected:
   /// Equivalent to setStatus(NodeStatus::IDLE)
   void resetStatus();
 
-  static void
-  defaultGeneralStatusUpdateCallback(TreeNode& tree_node, NodeStatus node_status,
-                                     Optional<general_status::GeneralStatus>& status);
-
   void appendChildGeneralStatus(const Optional<general_status::GeneralStatus>& status);
 
   Optional<general_status::GeneralStatus> general_status_;
-  
+
   GeneralStatusUpdateCallback general_status_update_callback_;
 
-private:  
+private:
   const std::string name_;
 
   NodeStatus status_;

--- a/include/behaviortree_cpp_v3/tree_node.h
+++ b/include/behaviortree_cpp_v3/tree_node.h
@@ -169,7 +169,7 @@ public:
   template <typename T>
   Result setOutput(const std::string& key, const T& value);
 
-  // function provide mostrly for debugging purpose to see the raw value
+  // function provide mostly for debugging purpose to see the raw value
   // in the port (no remapping and no conversion to a type)
   StringView getRawPortValue(const std::string& key) const;
 
@@ -196,6 +196,8 @@ public:
   void setGeneralStatusUpdateFunction(GeneralStatusUpdateCallback callback);
 
   const Optional<general_status::GeneralStatus>& getGeneralStatus() const;
+  
+  void resetGeneralStatus();
 
 protected:
   /// Method to be implemented by the user
@@ -226,7 +228,7 @@ protected:
 
   Optional<general_status::GeneralStatus> general_status_;
 
-private:
+private:  
   const std::string name_;
 
   NodeStatus status_;

--- a/src/behavior_tree.cpp
+++ b/src/behavior_tree.cpp
@@ -155,8 +155,8 @@ general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* root_node)
 
 void resetTreeGeneralStatus(TreeNode* root_node)
 {
-  auto visitor = [](TreeNode* root_node) {
-    root_node->resetGeneralStatus();
+  auto visitor = [](TreeNode* node) {
+    node->resetGeneralStatus();
   };
 
   applyRecursiveVisitor(root_node, visitor);

--- a/src/behavior_tree.cpp
+++ b/src/behavior_tree.cpp
@@ -113,22 +113,22 @@ void buildSerializedStatusSnapshot(TreeNode* root_node,
   applyRecursiveVisitor(root_node, visitor);
 }
 
-general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* node)
+general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* root_node)
 {
-  if (!node)
+  if (!root_node)
   {
     throw LogicError("One of the children of a DecoratorNode or ControlNode is "
                      "nullptr");
   }
-  if (!node->getGeneralStatus().has_value())
+  if (!root_node->getGeneralStatus().has_value())
   {
     throw LogicError("The node has no general status");
   }
 
   general_status::GeneralStatus tree_general_status =
-      node->getGeneralStatus().value().getCopy();
+      root_node->getGeneralStatus().value().getCopy();
 
-  if (auto control = dynamic_cast<const BT::ControlNode*>(node))
+  if (auto control = dynamic_cast<const BT::ControlNode*>(root_node))
   {
     for (const auto& child : control->children())
     {
@@ -140,7 +140,7 @@ general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* node)
       }
     }
   }
-  else if (auto decorator = dynamic_cast<const BT::DecoratorNode*>(node))
+  else if (auto decorator = dynamic_cast<const BT::DecoratorNode*>(root_node))
   {
     if (decorator->child() && decorator->child()->getGeneralStatus().has_value())
     {
@@ -151,6 +151,15 @@ general_status::GeneralStatus buildTreeGeneralStatus(const TreeNode* node)
   }
 
   return tree_general_status;
+}
+
+void resetTreeGeneralStatus(TreeNode* root_node)
+{
+  auto visitor = [](TreeNode* root_node) {
+    root_node->resetGeneralStatus();
+  };
+
+  applyRecursiveVisitor(root_node, visitor);
 }
 
 void printGeneralStatusRecursively(const general_status::GeneralStatus& status,

--- a/src/blackboard.cpp
+++ b/src/blackboard.cpp
@@ -109,6 +109,7 @@ Blackboard::createEntryImpl(const std::string &key, const PortInfo& info)
         prev_info.isStronglyTyped() &&
         info.isStronglyTyped())
     {
+      debugMessage();
       throw LogicError("Blackboard: once declared, the type of a port "
                        "shall not change. Previously declared type [",
                        BT::demangle(prev_info.type()), "] != new type [",

--- a/src/control_node.cpp
+++ b/src/control_node.cpp
@@ -77,4 +77,20 @@ void ControlNode::haltChildren(size_t first)
   }
 }
 
+
+void ControlNode::propagateGeneralStatusFromFailingChild(const TreeNode* failing_child)
+{
+  if (failing_child && failing_child->getGeneralStatus().has_value())
+  {
+    if (!general_status_.has_value())
+    {
+      general_status_ = failing_child->getGeneralStatus().value().getShallowCopy();
+    }
+    else
+    {
+      general_status_->mergeDataShallow(failing_child->getGeneralStatus().value());
+    }
+  }
+}
+
 }   // namespace BT

--- a/src/controls/fallback_node.cpp
+++ b/src/controls/fallback_node.cpp
@@ -19,6 +19,14 @@ FallbackNode::FallbackNode(const std::string& name) :
   ControlNode::ControlNode(name, {}), current_child_idx_(0)
 {
   setRegistrationID("Fallback");
+  setGeneralStatusUpdateFunction([&](TreeNode& /*tree_node*/, NodeStatus node_status,
+                                     Optional<general_status::GeneralStatus>& status) {
+    if (node_status == NodeStatus::FAILURE && !children_nodes_.empty())
+    {
+      status = children_nodes_.back()->getGeneralStatus().value().getShallowCopy();
+    }
+    TreeNode::defaultGeneralStatusUpdateCallback(*this, node_status, status);
+  });
 }
 
 NodeStatus FallbackNode::tick()

--- a/src/controls/fallback_node.cpp
+++ b/src/controls/fallback_node.cpp
@@ -19,14 +19,6 @@ FallbackNode::FallbackNode(const std::string& name) :
   ControlNode::ControlNode(name, {}), current_child_idx_(0)
 {
   setRegistrationID("Fallback");
-  setGeneralStatusUpdateFunction([&](TreeNode& /*tree_node*/, NodeStatus node_status,
-                                     Optional<general_status::GeneralStatus>& status) {
-    if (node_status == NodeStatus::FAILURE && !children_nodes_.empty())
-    {
-      status = children_nodes_.back()->getGeneralStatus().value().getShallowCopy();
-    }
-    TreeNode::defaultGeneralStatusUpdateCallback(*this, node_status, status);
-  });
 }
 
 NodeStatus FallbackNode::tick()
@@ -66,6 +58,11 @@ NodeStatus FallbackNode::tick()
   {
     resetChildren();
     current_child_idx_ = 0;
+  }
+
+  if (!children_nodes_.empty())
+  {
+    propagateGeneralStatusFromFailingChild(children_nodes_.back());
   }
 
   return NodeStatus::FAILURE;

--- a/src/controls/if_then_else_node.cpp
+++ b/src/controls/if_then_else_node.cpp
@@ -71,6 +71,10 @@ NodeStatus IfThenElseNode::tick()
     }
     else
     {
+      if (status == NodeStatus::FAILURE)
+      {
+        propagateGeneralStatusFromFailingChild(children_nodes_[child_idx_]);
+      }
       resetChildren();
       child_idx_ = 0;
       return status;

--- a/src/controls/manual_node.cpp
+++ b/src/controls/manual_node.cpp
@@ -79,6 +79,10 @@ NodeStatus ManualSelectorNode::tick()
   {
     running_child_idx_ = idx;
   }
+  if (ret == NodeStatus::FAILURE)
+  {
+    propagateGeneralStatusFromFailingChild(children_nodes_[idx]);
+  }
   return ret;
 }
 

--- a/src/controls/reactive_fallback.cpp
+++ b/src/controls/reactive_fallback.cpp
@@ -31,6 +31,7 @@ NodeStatus ReactiveFallback::tick()
         // the next time we tick them
         for (size_t i = 0; i < index; i++)
         {
+          appendChildGeneralStatus(children_nodes_[i]->getGeneralStatus());
           haltChild(i);
         }
         return NodeStatus::RUNNING;
@@ -54,6 +55,10 @@ NodeStatus ReactiveFallback::tick()
 
   if (failure_count == childrenCount())
   {
+    if (!children_nodes_.empty())
+    {
+      propagateGeneralStatusFromFailingChild(children_nodes_.back());
+    }
     resetChildren();
     return NodeStatus::FAILURE;
   }

--- a/src/controls/reactive_sequence.cpp
+++ b/src/controls/reactive_sequence.cpp
@@ -30,12 +30,14 @@ NodeStatus ReactiveSequence::tick()
         // the next time we tick them
         for (size_t i = 0; i < index; i++)
         {
+          appendChildGeneralStatus(children_nodes_[i]->getGeneralStatus());
           haltChild(i);
         }
         return NodeStatus::RUNNING;
       }
 
       case NodeStatus::FAILURE: {
+        propagateGeneralStatusFromFailingChild(current_child_node);
         resetChildren();
         return NodeStatus::FAILURE;
       }
@@ -49,7 +51,6 @@ NodeStatus ReactiveSequence::tick()
       }
     }   // end switch
   }     //end for
-
 
   if (success_count == childrenCount())
   {

--- a/src/controls/sequence_node.cpp
+++ b/src/controls/sequence_node.cpp
@@ -47,6 +47,7 @@ NodeStatus SequenceNode::tick()
       case NodeStatus::FAILURE: {
         // Reset on failure
         resetChildren();
+        propagateGeneralStatusFromFailingChild(current_child_node);
         current_child_idx_ = 0;
         return child_status;
       }

--- a/src/controls/sequence_node.cpp
+++ b/src/controls/sequence_node.cpp
@@ -46,8 +46,8 @@ NodeStatus SequenceNode::tick()
       }
       case NodeStatus::FAILURE: {
         // Reset on failure
-        resetChildren();
         propagateGeneralStatusFromFailingChild(current_child_node);
+        resetChildren();
         current_child_idx_ = 0;
         return child_status;
       }

--- a/src/controls/sequence_star_node.cpp
+++ b/src/controls/sequence_star_node.cpp
@@ -38,13 +38,12 @@ NodeStatus SequenceStarNode::tick()
         return child_status;
       }
       case NodeStatus::FAILURE: {
+        propagateGeneralStatusFromFailingChild(current_child_node);
         // DO NOT reset current_child_idx_ on failure
         for (size_t i = current_child_idx_; i < childrenCount(); i++)
         {
           haltChild(i);
         }
-
-        propagateGeneralStatusFromFailingChild(current_child_node);
         return child_status;
       }
       case NodeStatus::SUCCESS: {

--- a/src/controls/sequence_star_node.cpp
+++ b/src/controls/sequence_star_node.cpp
@@ -44,6 +44,7 @@ NodeStatus SequenceStarNode::tick()
           haltChild(i);
         }
 
+        propagateGeneralStatusFromFailingChild(current_child_node);
         return child_status;
       }
       case NodeStatus::SUCCESS: {

--- a/src/controls/while_do_else_node.cpp
+++ b/src/controls/while_do_else_node.cpp
@@ -44,18 +44,14 @@ NodeStatus WhileDoElseNode::tick()
   }
 
   NodeStatus status = NodeStatus::IDLE;
-
-  if (condition_status == NodeStatus::SUCCESS)
+  int child_index_to_execute = (condition_status == NodeStatus::SUCCESS) ? 1 : 2;
+  int child_index_to_halt = (condition_status == NodeStatus::SUCCESS) ? 2 : 1;
+  haltChild(child_index_to_halt);
+  status = children_nodes_[child_index_to_execute]->executeTick();
+  if (status == NodeStatus::FAILURE)
   {
-    haltChild(2);
-    status = children_nodes_[1]->executeTick();
+    propagateGeneralStatusFromFailingChild(children_nodes_[child_index_to_execute]);
   }
-  else if (condition_status == NodeStatus::FAILURE)
-  {
-    haltChild(1);
-    status = children_nodes_[2]->executeTick();
-  }
-
   if (status == NodeStatus::RUNNING)
   {
     return NodeStatus::RUNNING;

--- a/src/decorators/repeat_node.cpp
+++ b/src/decorators/repeat_node.cpp
@@ -53,6 +53,7 @@ NodeStatus RepeatNode::tick()
     {
       case NodeStatus::SUCCESS: {
         repeat_count_++;
+        appendChildGeneralStatus(child_node_->getGeneralStatus());
         resetChild();
       }
       break;

--- a/src/decorators/retry_node.cpp
+++ b/src/decorators/retry_node.cpp
@@ -64,6 +64,7 @@ NodeStatus RetryNode::tick()
 
       case NodeStatus::FAILURE: {
         try_count_++;
+        appendChildGeneralStatus(child_node_->getGeneralStatus());
         resetChild();
       }
       break;

--- a/src/tree_node.cpp
+++ b/src/tree_node.cpp
@@ -23,12 +23,12 @@ static uint16_t getUID()
 }
 
 TreeNode::TreeNode(std::string name, NodeConfiguration config) :
+  general_status_(nonstd::unexpected_type<std::string>("GeneralStatus not set")),
   name_(std::move(name)),
   status_(NodeStatus::IDLE),
   uid_(getUID()),
   config_(std::move(config)),
-  general_status_(nonstd::unexpected_type<std::string>("GeneralStatus not set")),
-  general_status_update_callback_(getDefaultGeneralStatusUpdateCallback())
+  general_status_update_callback_(&TreeNode::defaultGeneralStatusUpdateCallback)
 {}
 
 NodeStatus TreeNode::executeTick()
@@ -64,7 +64,7 @@ NodeStatus TreeNode::executeTick()
   // Update General status if node operation is completed
   if (StatusCompleted(new_status))
   {
-    general_status_ = general_status_update_callback_(*this, new_status);
+    general_status_update_callback_(*this, new_status, general_status_);
   }
 
   setStatus(new_status);
@@ -256,15 +256,39 @@ const Optional<general_status::GeneralStatus>& TreeNode::getGeneralStatus() cons
   return general_status_;
 }
 
-TreeNode::GeneralStatusUpdateCallback TreeNode::getDefaultGeneralStatusUpdateCallback()
+void TreeNode::defaultGeneralStatusUpdateCallback(
+    TreeNode& tree_node, NodeStatus node_status,
+    Optional<general_status::GeneralStatus>& status)
 {
-  return [](TreeNode& tree_node, NodeStatus node_status) {
-    auto status = general_status::GeneralStatus();
-    status.opt_string_ = tree_node.name() + " - " + toStr(node_status);
-    status.uuid_ = "Tree Node UID: " + std::to_string(tree_node.UID());
-    status.status_code_ = node_status == NodeStatus::SUCCESS ? 0 : 2000000;
-    return status;
-  };
+  // Always override uuid and opt_string. Update status_code if not set previously.
+  if (!status.has_value())
+  {
+    status = general_status::GeneralStatus();
+  }
+  status.value().opt_string_ = "Name: '" + tree_node.name() + "' Type: '" +
+                               toStr(tree_node.type()) + "' Status: '" +
+                               toStr(node_status) + "'";
+  status.value().uuid_ = "Tree Node UID: " + std::to_string(tree_node.UID());
+  if (node_status == NodeStatus::FAILURE &&
+      status.value().status_code_ == general_status::BtErrorCodes::OK)
+  {
+    status.value().status_code_ =
+        general_status::BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE;
+  }
+}
+
+void TreeNode::appendChildGeneralStatus(const Optional<general_status::GeneralStatus>& status)
+{
+  if(!status.has_value())
+  {
+    throw RuntimeError("The child node for appending has no general status");
+  }
+  if (!general_status_)
+  {
+    general_status_ = general_status::GeneralStatus();
+  }
+  general_status_->underlying_status_messages_.emplace_back(
+      std::make_unique<general_status::GeneralStatus>(status.value().getCopy()));
 }
 
 }   // namespace BT

--- a/src/tree_node.cpp
+++ b/src/tree_node.cpp
@@ -24,11 +24,11 @@ static uint16_t getUID()
 
 TreeNode::TreeNode(std::string name, NodeConfiguration config) :
   general_status_(nonstd::unexpected_type<std::string>("GeneralStatus not set")),
+  general_status_update_callback_(&TreeNode::defaultGeneralStatusUpdateCallback),
   name_(std::move(name)),
   status_(NodeStatus::IDLE),
   uid_(getUID()),
-  config_(std::move(config)),
-  general_status_update_callback_(&TreeNode::defaultGeneralStatusUpdateCallback)
+  config_(std::move(config))
 {}
 
 NodeStatus TreeNode::executeTick()

--- a/src/tree_node.cpp
+++ b/src/tree_node.cpp
@@ -34,6 +34,13 @@ TreeNode::TreeNode(std::string name, NodeConfiguration config) :
 NodeStatus TreeNode::executeTick()
 {
   NodeStatus new_status = status_;
+
+  // Reset General status on first tick after a node is halted
+  if (isHalted())
+  {
+    resetGeneralStatus();
+  }
+
   // a pre-condition may return the new status.
   // In this case it override the actual tick()
   Optional<NodeStatus> pre_condition_result = nonstd::unexpected_type<std::string>("");
@@ -256,6 +263,11 @@ const Optional<general_status::GeneralStatus>& TreeNode::getGeneralStatus() cons
   return general_status_;
 }
 
+void TreeNode::resetGeneralStatus()
+{
+  general_status_ = nonstd::unexpected_type<std::string>("GeneralStatus not set");
+}
+
 void TreeNode::defaultGeneralStatusUpdateCallback(
     TreeNode& tree_node, NodeStatus node_status,
     Optional<general_status::GeneralStatus>& status)
@@ -277,9 +289,10 @@ void TreeNode::defaultGeneralStatusUpdateCallback(
   }
 }
 
-void TreeNode::appendChildGeneralStatus(const Optional<general_status::GeneralStatus>& status)
+void TreeNode::appendChildGeneralStatus(
+    const Optional<general_status::GeneralStatus>& status)
 {
-  if(!status.has_value())
+  if (!status.has_value())
   {
     throw RuntimeError("The child node for appending has no general status");
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(BT_TESTS
   gtest_subtree.cpp
   gtest_switch.cpp
   gtest_wakeup.cpp
+  gtest_general_status_decorators.cpp
 )
 
 if( ZMQ_FOUND )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(BT_TESTS
   gtest_subtree.cpp
   gtest_switch.cpp
   gtest_wakeup.cpp
+  src/status_action_test_node.cpp
   gtest_general_status_decorators.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BT_TESTS
   gtest_wakeup.cpp
   src/status_action_test_node.cpp
   gtest_general_status_decorators.cpp
+  gtest_general_status_control.cpp
 )
 
 if( ZMQ_FOUND )

--- a/tests/gtest_general_status_control.cpp
+++ b/tests/gtest_general_status_control.cpp
@@ -61,10 +61,9 @@ TEST_F(GeneralStatusControlTest, Fallback)
 
   const auto& status = root_->getGeneralStatus();
   ASSERT_TRUE(status.has_value()) << "Root node status not set";
-  EXPECT_EQ(status.value().status_code_, BtErrorCodes::OK) << "Root node "
-                                                              "status "
-                                                              "mismatch";
-  root_->halt();
+  EXPECT_EQ(status.value().status_code_, BtErrorCodes::OK) << "Root status mismatch";
+
+  // reset GS or reset node status to IDLE
   root_->resetGeneralStatus();
 
   // 2: A(FAIL) -> B(FAIL) -> OUTPUT: FAIL (B)

--- a/tests/gtest_general_status_control.cpp
+++ b/tests/gtest_general_status_control.cpp
@@ -1,0 +1,132 @@
+/* Copyright (C) 2015-2017 Michele Colledanchise - All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <gtest/gtest.h>
+#include "action_test_node.h"
+#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "status_action_test_node.h"
+
+using BT::NodeStatus;
+using BT::general_status::BtErrorCodes;
+using BT::general_status::EnumType;
+using std::chrono::milliseconds;
+
+class GeneralStatusControlTest : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {}
+
+  void TearDown() override
+  {}
+
+protected:
+  std::unique_ptr<BT::ControlNode> root_;
+  std::vector<std::unique_ptr<StatusActionTestNode>> actions_;
+
+  std::function<void()> createRoot_;
+};
+
+/****************TESTS START HERE***************************/
+TEST_F(GeneralStatusControlTest, Fallback)
+{
+  // Fallback
+  // 1: A(FAIL) -> B(OK) -> OUTPUT: OK
+  actions_.push_back(std::make_unique<StatusActionTestNode>("A"));
+  actions_.push_back(std::make_unique<StatusActionTestNode>("B"));
+  actions_[0]->setExpectedCode(13);
+  actions_[1]->setExpectedCode(123);
+
+  root_ = std::make_unique<BT::FallbackNode>("FallbackNode");
+  root_->addChild(actions_[0].get());
+  root_->addChild(actions_[1].get());
+
+  actions_[0]->setExpectedResult(NodeStatus::FAILURE);
+  actions_[1]->setExpectedResult(NodeStatus::SUCCESS);
+
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "First node is running";
+  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (1)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "Second node is running";
+  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (2)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::SUCCESS) << "Fallback return success";
+
+  const auto& status = root_->getGeneralStatus();
+  ASSERT_TRUE(status.has_value()) << "Root node status not set";
+  EXPECT_EQ(status.value().status_code_, BtErrorCodes::OK) << "Root node "
+                                                              "status "
+                                                              "mismatch";
+  root_->halt();
+  root_->resetGeneralStatus();
+
+  // 2: A(FAIL) -> B(FAIL) -> OUTPUT: FAIL (B)
+  actions_[0]->setExpectedResult(NodeStatus::FAILURE);
+  actions_[1]->setExpectedResult(NodeStatus::FAILURE);
+
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "First node is running";
+  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (1)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "Second node is running";
+  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (2)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::FAILURE) << "Fallback return failure";
+
+  const auto& status2 = root_->getGeneralStatus();
+  ASSERT_TRUE(status2.has_value()) << "Root node status not set";
+  EXPECT_EQ(status2.value().status_code_, actions_[1]->getExpectedCode()) << "Root node "
+                                                                             "status "
+                                                                             "mismatch";
+
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, IfThenElse)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, Manual)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, Parallel)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, ReactiveFallback)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, ReactiveSequence)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, Sequence)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, SequenceStar)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, Switch)
+{
+  SUCCEED();
+}
+
+TEST_F(GeneralStatusControlTest, WhileDoElse)
+{
+  SUCCEED();
+}

--- a/tests/gtest_general_status_control.cpp
+++ b/tests/gtest_general_status_control.cpp
@@ -157,24 +157,22 @@ TEST_F(GeneralStatusControlTest, Parallel)
   root_->addChild(actions_[1].get());
   root_->addChild(actions_[2].get());
 
-  // 1: A(OK), B(FAIL), C(FAIL) -> OUTPUT: FAIL(B)
-  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE, NodeStatus::FAILURE});
-  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE},
-          getExpectedCode(1), "1");
+  // 1: A(OK), B(FAIL), C(OK) -> OUTPUT: FAIL(B)
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE}, getExpectedCode(1), "1");
 
   // 2: A(OK), B(OK), C(OK) -> OUTPUT: OK
   setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS, NodeStatus::SUCCESS});
   runTest({NodeStatus::RUNNING, NodeStatus::SUCCESS}, BtErrorCodes::OK, "2");
 
-  // 3: A(FAIL), B(FAIL), C(FAIL) -> OUTPUT: FAIL(A)
+  // 3: A(FAIL), B(FAIL), C(FAIL) -> OUTPUT: FAIL(BEHAVIOR_TREE_PARALLEL_NODE_MULTIPLE_FAILURES)
   setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE, NodeStatus::FAILURE});
   runTest({NodeStatus::RUNNING, NodeStatus::FAILURE},
-          getExpectedCode(0), "3");  
+          BtErrorCodes::BEHAVIOR_TREE_PARALLEL_NODE_MULTIPLE_FAILURES, "3");
 
-  // 4: A(OK), B(FAIL), C(OK) -> OUTPUT: FAIL(B)
+  // 4: A(FAIL), B(OK), C(OK) -> OUTPUT: FAIL(A)
   setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE, NodeStatus::SUCCESS});
-  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE},
-          getExpectedCode(1), "4");  
+  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE}, getExpectedCode(0), "4");
 
   SUCCEED();
 }

--- a/tests/gtest_general_status_control.cpp
+++ b/tests/gtest_general_status_control.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 #include "action_test_node.h"
 #include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp_v3/actions/always_failure_node.h"
 #include "status_action_test_node.h"
 
 using BT::NodeStatus;
@@ -24,7 +25,14 @@ class GeneralStatusControlTest : public ::testing::Test
 {
 public:
   void SetUp() override
-  {}
+  {
+    actions_.emplace_back(std::make_unique<StatusActionTestNode>("A"));
+    actions_.emplace_back(std::make_unique<StatusActionTestNode>("B"));
+    actions_.emplace_back(std::make_unique<StatusActionTestNode>("C"));
+    actions_[0]->setExpectedCode(13);
+    actions_[1]->setExpectedCode(123);
+    actions_[2]->setExpectedCode(1234);
+  }
 
   void TearDown() override
   {}
@@ -34,98 +42,309 @@ protected:
   std::vector<std::unique_ptr<StatusActionTestNode>> actions_;
 
   std::function<void()> createRoot_;
+
+  void setExpectedResults(std::vector<NodeStatus> results)
+  {
+    for (size_t i = 0; i < results.size(); i++)
+    {
+      actions_.at(i)->setExpectedResult(results[i]);
+    }
+  }
+
+  EnumType getExpectedCode(int idx)
+  {
+    return actions_.at(idx)->getExpectedCode();
+  }
+
+  void runTest(std::vector<NodeStatus> expectedStatuses, EnumType expectedCode,
+               std::string name)
+  {
+    resetRoot();
+    for (size_t i = 0; i < expectedStatuses.size(); i++)
+    {
+      EXPECT_EQ(root_->executeTick(), expectedStatuses.at(i))
+          << "Test " << name << " step " << i << " status mismatch";
+      if (i < expectedStatuses.size() - 1)
+        EXPECT_FALSE(root_->getGeneralStatus().has_value())
+            << "Test " << name << " step " << i << " status present";
+    }
+    const auto& status = root_->getGeneralStatus();
+    ASSERT_TRUE(status.has_value()) << "Test " << name << " final status not set";
+    EXPECT_EQ(status.value().status_code_, expectedCode)
+        << "Test " << name << " final code mismatch";
+  }
+
+  void resetRoot()
+  {
+    root_->halt();   // this should be already called, but it is still sometimes needed
+    root_->resetGeneralStatus();
+  }
 };
 
 /****************TESTS START HERE***************************/
 TEST_F(GeneralStatusControlTest, Fallback)
 {
   // Fallback
-  // 1: A(FAIL) -> B(OK) -> OUTPUT: OK
-  actions_.push_back(std::make_unique<StatusActionTestNode>("A"));
-  actions_.push_back(std::make_unique<StatusActionTestNode>("B"));
-  actions_[0]->setExpectedCode(13);
-  actions_[1]->setExpectedCode(123);
-
   root_ = std::make_unique<BT::FallbackNode>("FallbackNode");
   root_->addChild(actions_[0].get());
   root_->addChild(actions_[1].get());
 
-  actions_[0]->setExpectedResult(NodeStatus::FAILURE);
-  actions_[1]->setExpectedResult(NodeStatus::SUCCESS);
-
-  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "First node is running";
-  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (1)";
-  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "Second node is running";
-  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (2)";
-  EXPECT_EQ(root_->executeTick(), NodeStatus::SUCCESS) << "Fallback return success";
-
-  const auto& status = root_->getGeneralStatus();
-  ASSERT_TRUE(status.has_value()) << "Root node status not set";
-  EXPECT_EQ(status.value().status_code_, BtErrorCodes::OK) << "Root status mismatch";
-
-  // reset GS or reset node status to IDLE
-  root_->resetGeneralStatus();
+  // 1: A(FAIL) -> B(OK) -> OUTPUT: OK
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::SUCCESS},
+          BtErrorCodes::OK, "1");
 
   // 2: A(FAIL) -> B(FAIL) -> OUTPUT: FAIL (B)
-  actions_[0]->setExpectedResult(NodeStatus::FAILURE);
-  actions_[1]->setExpectedResult(NodeStatus::FAILURE);
-
-  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "First node is running";
-  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (1)";
-  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "Second node is running";
-  EXPECT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status present (2)";
-  EXPECT_EQ(root_->executeTick(), NodeStatus::FAILURE) << "Fallback return failure";
-
-  const auto& status2 = root_->getGeneralStatus();
-  ASSERT_TRUE(status2.has_value()) << "Root node status not set";
-  EXPECT_EQ(status2.value().status_code_, actions_[1]->getExpectedCode()) << "Root node "
-                                                                             "status "
-                                                                             "mismatch";
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::FAILURE},
+          getExpectedCode(1), "2");
 
   SUCCEED();
 }
 
 TEST_F(GeneralStatusControlTest, IfThenElse)
 {
+  // [BUG]: IfThenElseNode is not halting child A if there is no child C
+
+  // IfThenElse (A&B only)
+  root_ = std::make_unique<BT::IfThenElseNode>("IfThenElseNode");
+  root_->addChild(actions_[0].get());
+  root_->addChild(actions_[1].get());
+
+  // 1(no C): A(FAIL) -> FAIL (generic error)
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE});
+  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE},
+          BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE, "1");
+
+  // Add third child (C)
+  root_->addChild(actions_[2].get());
+
+  // 2: A(FAIL) -> C(FAIL) -> FAIL
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE, NodeStatus::FAILURE});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::FAILURE},
+          getExpectedCode(2), "2");
+
+  // 3: A(FAIL) -> C(OK) -> OK
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::SUCCESS},
+          BtErrorCodes::OK, "3");
+
+  // 4: A(OK) -> B(FAIL) -> FAIL
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::FAILURE},
+          getExpectedCode(1), "4");
+
+  // 5: A(OK) -> B(OK) -> OK
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::SUCCESS},
+          BtErrorCodes::OK, "5");
+
   SUCCEED();
 }
 
-TEST_F(GeneralStatusControlTest, Manual)
-{
-  SUCCEED();
-}
+// Manual node is not trivial to test automatically
+// TEST_F(GeneralStatusControlTest, Manual)
+// {
+//   SUCCEED();
+// }
 
 TEST_F(GeneralStatusControlTest, Parallel)
 {
+  // Parallel
+  // There is no propagation in parallel node, because it can have multiple failed children
+  root_ = std::make_unique<BT::ParallelNode>("ParallelNode", -1, 2);
+  root_->addChild(actions_[0].get());
+  root_->addChild(actions_[1].get());
+  root_->addChild(actions_[2].get());
+
+  // 1: A(FAIL) -> B(OK) -> OUTPUT: OK
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE},
+          BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE, "1");
+
+  // 2: A(FAIL) -> B(FAIL) -> OUTPUT: FAIL (B)
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::SUCCESS}, BtErrorCodes::OK, "2");
+
   SUCCEED();
 }
 
 TEST_F(GeneralStatusControlTest, ReactiveFallback)
 {
+  // ReactiveFallback
+  // Reactive fallback resets & retries all previous children when a child is running.
+  // We need to use immediate nodes here, because otherwise it will go into infinite loop.
+  root_ = std::make_unique<BT::ReactiveFallback>("ReactiveFallback");
+  auto action0 = std::make_unique<BT::AlwaysFailureNode>("A");
+  auto action1 = std::make_unique<BT::AlwaysFailureNode>("B");
+  root_->addChild(action0.get());
+  root_->addChild(action1.get());
+  root_->addChild(actions_[0].get());
+
+  // 1: A(FAIL) -> B(FAIL) -> C(OK) -> OUTPUT: OK
+  setExpectedResults({NodeStatus::SUCCESS});
+  resetRoot();
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "root status mismatch (1)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::SUCCESS) << "root status mismatch (2)";
+  EXPECT_EQ(root_->getGeneralStatus().value().status_code_, BtErrorCodes::OK);
+  // expect 2 children: A,B
+  EXPECT_EQ(root_->getGeneralStatus().value().underlying_status_messages_.size(), 2U);
+  // BT::printGeneralStatusRecursively(root_->getGeneralStatus().value());  // debug
+
+  // 2: A(FAIL) -> B(FAIL) -> C(FAIL) -> OUTPUT: FAIL
+  setExpectedResults({NodeStatus::FAILURE});
+  resetRoot();
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "root status mismatch (1)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::FAILURE) << "root status mismatch (2)";
+  EXPECT_EQ(root_->getGeneralStatus().value().status_code_, getExpectedCode(0));
+  // expect 2 children: A,B
+  EXPECT_EQ(root_->getGeneralStatus().value().underlying_status_messages_.size(), 2U);
+  // BT::printGeneralStatusRecursively(root_->getGeneralStatus().value());  // debug
+
   SUCCEED();
 }
 
 TEST_F(GeneralStatusControlTest, ReactiveSequence)
 {
+  // ReactiveSequence
+  // Reactive sequence resets & retries all previous children when a child is running.
+  // We need to use immediate nodes here, because otherwise it will go into infinite loop.
+  root_ = std::make_unique<BT::ReactiveSequence>("ReactiveFallback");
+  auto action0 = std::make_unique<BT::AlwaysSuccessNode>("A");
+  auto action1 = std::make_unique<BT::AlwaysSuccessNode>("B");
+  root_->addChild(action0.get());
+  root_->addChild(action1.get());
+  root_->addChild(actions_[0].get());
+
+  // 1: A(OK) -> B(OK) -> C(OK) -> OUTPUT: OK
+  setExpectedResults({NodeStatus::SUCCESS});
+  resetRoot();
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "root status mismatch (1)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::SUCCESS) << "root status mismatch (2)";
+  EXPECT_EQ(root_->getGeneralStatus().value().status_code_, BtErrorCodes::OK);
+  // expect 2 children: A,B
+  EXPECT_EQ(root_->getGeneralStatus().value().underlying_status_messages_.size(), 2U);
+  // BT::printGeneralStatusRecursively(root_->getGeneralStatus().value());   // debug
+
+  // 2: A(OK) -> B(OK) -> C(FAIL) -> OUTPUT: FAIL
+  setExpectedResults({NodeStatus::FAILURE});
+  resetRoot();
+  EXPECT_EQ(root_->executeTick(), NodeStatus::RUNNING) << "root status mismatch (1)";
+  EXPECT_EQ(root_->executeTick(), NodeStatus::FAILURE) << "root status mismatch (2)";
+  EXPECT_EQ(root_->getGeneralStatus().value().status_code_, getExpectedCode(0));
+  // expect 2 children: A,B
+  EXPECT_EQ(root_->getGeneralStatus().value().underlying_status_messages_.size(), 2U);
+  // BT::printGeneralStatusRecursively(root_->getGeneralStatus().value());   // debug
+
   SUCCEED();
 }
 
 TEST_F(GeneralStatusControlTest, Sequence)
 {
+  // Sequence
+  root_ = std::make_unique<BT::SequenceNode>("SequenceNode");
+  root_->addChild(actions_[0].get());
+  root_->addChild(actions_[1].get());
+
+  // 1: A(OK) -> B(OK) -> OUTPUT: OK
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::SUCCESS},
+          BtErrorCodes::OK, "1");
+
+  // 2: A(OK) -> B(FAIL) -> OUTPUT: FAIL (B)
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::FAILURE},
+          getExpectedCode(1), "2");
+
   SUCCEED();
 }
 
 TEST_F(GeneralStatusControlTest, SequenceStar)
 {
+  // SequenceStarNode
+  // The only difference between Sequence and SequenceStar it that the failed node is not reset
+  // It does not affect propagation
+  root_ = std::make_unique<BT::SequenceStarNode>("SequenceStarNode");
+  root_->addChild(actions_[0].get());
+  root_->addChild(actions_[1].get());
+
+  // 1: A(OK) -> B(OK) -> OUTPUT: OK
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::SUCCESS},
+          BtErrorCodes::OK, "1");
+
+  // 2: A(OK) -> B(FAIL) -> OUTPUT: FAIL (B)
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::FAILURE},
+          getExpectedCode(1), "2");
+
   SUCCEED();
 }
 
 TEST_F(GeneralStatusControlTest, Switch)
 {
+  // SwitchNode
+  BT::NodeConfiguration config;
+  BT::assignDefaultRemapping<BT::SwitchNode<2>>(config);
+  config.blackboard = BT::Blackboard::create();
+
+  root_ = std::make_unique<BT::SwitchNode<2>>("SwitchNode", config);
+  root_->addChild(actions_[0].get());
+  root_->addChild(actions_[1].get());
+  root_->addChild(actions_[2].get());
+
+  // 1: no variable -> use default(C) C(FAIL) -> OUTPUT: FAIL
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS, NodeStatus::FAILURE});
+  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE}, getExpectedCode(2), "1");
+
+  config.blackboard->set<std::string>("variable", "F");
+  config.blackboard->set<std::string>("case_1", "A");
+  config.blackboard->set<std::string>("case_2", "B");
+
+  // 2: variable do not match case -> use default(C) C(OK) -> OUTPUT: OK
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::SUCCESS}, BtErrorCodes::OK, "2");
+
+  // 3: variable == A -> A(FAIL) -> OUTPUT: FAIL
+  config.blackboard->set<std::string>("variable", "A");
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::SUCCESS, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE}, getExpectedCode(0), "3");
+
+  // 4: variable == B -> B(FAIL) -> OUTPUT: FAIL
+  config.blackboard->set<std::string>("variable", "B");
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::FAILURE}, getExpectedCode(1), "4");
+
   SUCCEED();
 }
 
 TEST_F(GeneralStatusControlTest, WhileDoElse)
 {
+  // WhileDoElseNode
+  root_ = std::make_unique<BT::WhileDoElseNode>("WhileDoElseNode");
+  root_->addChild(actions_[0].get());
+  root_->addChild(actions_[1].get());
+  root_->addChild(actions_[2].get());
+
+  // 2: A(FAIL) -> C(FAIL) -> FAIL
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE, NodeStatus::FAILURE});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::FAILURE},
+          getExpectedCode(2), "2");
+
+  // 3: A(FAIL) -> C(OK) -> OK
+  setExpectedResults({NodeStatus::FAILURE, NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::SUCCESS},
+          BtErrorCodes::OK, "3");
+
+  // 4: A(OK) -> B(FAIL) -> FAIL
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::FAILURE, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::FAILURE},
+          getExpectedCode(1), "4");
+
+  // 5: A(OK) -> B(OK) -> OK
+  setExpectedResults({NodeStatus::SUCCESS, NodeStatus::SUCCESS, NodeStatus::SUCCESS});
+  runTest({NodeStatus::RUNNING, NodeStatus::RUNNING, NodeStatus::SUCCESS},
+          BtErrorCodes::OK, "5");
+
   SUCCEED();
 }

--- a/tests/gtest_general_status_decorators.cpp
+++ b/tests/gtest_general_status_decorators.cpp
@@ -1,0 +1,491 @@
+/* Copyright (C) 2015-2017 Michele Colledanchise - All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <gtest/gtest.h>
+#include "action_test_node.h"
+#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp_v3/decorators/consume_queue.h"
+
+using BT::NodeStatus;
+using BT::general_status::BtErrorCodes;
+using BT::general_status::EnumType;
+using std::chrono::milliseconds;
+
+class SimpleAction : public BT::ActionNodeBase
+{
+public:
+  SimpleAction(const std::string& name);
+  BT::NodeStatus tick() override;
+  void setExpectedResult(NodeStatus res);
+  void setExpectedCode(BT::general_status::EnumType code);
+  int tickCount() const;
+  void resetTicks();
+  void halt() override;
+
+private:
+  NodeStatus expected_result_;
+  int tick_count_;
+};
+
+SimpleAction::SimpleAction(const std::string& name) : BT::ActionNodeBase(name, {})
+{
+  tick_count_ = 0;
+  expected_result_ = NodeStatus::IDLE;
+}
+
+int SimpleAction::tickCount() const
+{
+  return tick_count_;
+}
+
+void SimpleAction::resetTicks()
+{
+  tick_count_ = 0;
+}
+
+void SimpleAction::halt()
+{
+  resetTicks();
+}
+
+BT::NodeStatus SimpleAction::tick()
+{
+  if (status() == NodeStatus::IDLE)
+    resetTicks();
+  tick_count_++;
+  if (tick_count_ == 1)
+    return NodeStatus::RUNNING;
+  return expected_result_;
+}
+
+void SimpleAction::setExpectedResult(NodeStatus res)
+{
+  expected_result_ = res;
+}
+
+void SimpleAction::setExpectedCode(BT::general_status::EnumType code)
+{
+  setGeneralStatusUpdateFunction(
+      [code](TreeNode& tree_node, NodeStatus node_status,
+             BT::Optional<BT::general_status::GeneralStatus>& status) {
+        status = BT::general_status::GeneralStatus();
+        status->status_code_ = code;
+      });
+}
+
+class GeneralStatusDecoratorTest : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {}
+
+  void TearDown() override
+  {}
+
+  void initialize(NodeStatus actionResult, EnumType actionCode)
+  {
+    action_ = std::make_unique<SimpleAction>("action");
+    action_->setExpectedResult(actionResult);
+    action_->setExpectedCode(actionCode);
+    root_->setChild(action_.get());
+  }
+
+  void runTest(NodeStatus expectedResult, EnumType expectedCode,
+               EnumType expectedChildCode, const std::string& desc)
+  {
+    // first tick - node should be running
+    BT::NodeStatus state = root_->executeTick();
+    if (root_->name() == "DelayNode")
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(defaultDelayMs_));
+      state = root_->executeTick();
+    }
+    EXPECT_EQ(state, NodeStatus::RUNNING) << desc << ": Root node finished too soon";
+    ASSERT_FALSE(root_->getGeneralStatus().has_value())
+        << desc << ": Root node status already set";
+
+    // second tick - check result
+    state = root_->executeTick();
+    EXPECT_EQ(state, expectedResult) << desc << ": Root node not finished";
+    const auto& status = root_->getGeneralStatus();
+    ASSERT_TRUE(status.has_value()) << desc << ": Root node status not set";
+    EXPECT_EQ(status.value().status_code_, expectedCode)
+        << desc << ": Root node status mismatch";
+
+    EXPECT_EQ(action_->status(), NodeStatus::IDLE);
+    const auto& child_status = action_->getGeneralStatus();
+    ASSERT_TRUE(child_status.has_value()) << desc << ": Child node status not set";
+    EXPECT_EQ(child_status.value().status_code_, expectedChildCode) << desc
+                                                                    << ": Child node "
+                                                                       "status "
+                                                                       "mismatch";
+  }
+
+  void runFixture(NodeStatus childStatus, EnumType childCode, NodeStatus rootStatus,
+                  EnumType rootCode, std::string desc)
+  {
+    createRoot_();
+    initialize(childStatus, childCode);
+    runTest(rootStatus, rootCode, childCode, desc);
+  }
+
+  void runDefaultFixtures()
+  {
+    // Assume decorator do nothing - just propagate error as is
+
+    // child success with OK
+    runFixture(NodeStatus::SUCCESS, BtErrorCodes::OK, NodeStatus::SUCCESS,
+               BtErrorCodes::OK, "Ch: SUCCESS:OK, R: FAILURE:OK");
+
+    // child success with warning
+    runFixture(NodeStatus::SUCCESS, 13, NodeStatus::SUCCESS, BtErrorCodes::OK,
+               "Ch: SUCCESS:13, R: SUCCESS:OK");
+
+    // child failure with OK
+    runFixture(NodeStatus::FAILURE, BtErrorCodes::OK, NodeStatus::FAILURE,
+               BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE,
+               "Ch: FAILURE:OK, R: FAILURE:BEHAVIOR_TREE_NODE_FAILURE");
+
+    // child failure with error
+    runFixture(NodeStatus::FAILURE, 154, NodeStatus::FAILURE, 154,
+               "Ch: FAILURE:154, R: FAILURE:154");
+  }
+
+  void runRootFixture(NodeStatus rootStatus, EnumType rootCode, std::string desc = "")
+  {
+    createRoot_();
+    initialize(NodeStatus::FAILURE, BtErrorCodes::OK);
+    auto state = root_->executeTick();
+    EXPECT_EQ(state, rootStatus) << "runRootFixture: Root node not finished";
+    const auto& status = root_->getGeneralStatus();
+    ASSERT_TRUE(status.has_value()) << "runRootFixture: Root node status not set";
+    EXPECT_EQ(status.value().status_code_, rootCode) << "Root node status mismatch";
+
+    EXPECT_EQ(action_->status(), NodeStatus::IDLE) << "runRootFixture: Child node not "
+                                                      "idle";
+    const auto& child_status = action_->getGeneralStatus();
+    ASSERT_FALSE(child_status.has_value()) << "runRootFixture: Child node status set";
+  }
+
+protected:
+  std::unique_ptr<BT::DecoratorNode> root_;
+  std::unique_ptr<SimpleAction> action_;
+
+  std::function<void()> createRoot_;
+
+  const int defaultDelayMs_ = 10;
+};
+
+/****************TESTS START HERE***************************/
+//12 tests
+TEST_F(GeneralStatusDecoratorTest, BlackboardPrecondition)
+{
+  auto bb = BT::Blackboard::create();
+  BT::NodeConfiguration config;
+  BT::assignDefaultRemapping<BT::BlackboardPreconditionNode<int>>(config);
+  config.blackboard = bb;
+
+  const auto answer = 42;
+  config.blackboard->set<int>("value_A", answer);
+  config.blackboard->set<int>("value_B", answer);
+  config.blackboard->set<BT::NodeStatus>("return_on_mismatch", BT::NodeStatus::FAILURE);
+
+  createRoot_ = [this, &config]() {
+    root_ = std::make_unique<BT::BlackboardPreconditionNode<int>>("BlackboardPrecond",
+                                                                  config);
+  };
+
+  runDefaultFixtures();
+
+  // root failure -> report error and do not tick child
+  config.blackboard->set<int>("value_A", 111);
+  runRootFixture(NodeStatus::FAILURE, BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE);
+}
+
+TEST_F(GeneralStatusDecoratorTest, ConsumeQueue)
+{
+  // This node is rarely used so this test is not exhaustive
+
+  auto bb = BT::Blackboard::create();
+  BT::NodeConfiguration config;
+  BT::assignDefaultRemapping<BT::ProtectedQueue<int>>(config);
+  config.blackboard = bb;
+
+  const auto answer = 42;
+  config.blackboard->set<std::shared_ptr<BT::ProtectedQueue<int>>>(
+      "queue", std::make_shared<BT::ProtectedQueue<int>>());
+  createRoot_ = [this, &config]() {
+    root_ = std::make_unique<BT::ConsumeQueue<int>>("ConsumeQueue", config);
+  };
+
+  // no queue -> success
+  runRootFixture(NodeStatus::SUCCESS, BtErrorCodes::OK);
+}
+
+TEST_F(GeneralStatusDecoratorTest, DelayNode)
+{
+  // Name is an identifier for this test to work properly!
+  createRoot_ = [&]() { root_ = std::make_unique<BT::DelayNode>("DelayNode", 1); };
+
+  runDefaultFixtures();
+}
+
+TEST_F(GeneralStatusDecoratorTest, ForceFailureNode)
+{
+  createRoot_ = [&]() {
+    root_ = std::make_unique<BT::ForceFailureNode>("ForceFailureNode");
+  };
+
+  // child success with OK
+  runFixture(NodeStatus::SUCCESS, BtErrorCodes::OK, NodeStatus::FAILURE,
+             BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE,
+             "Ch: SUCCESS:OK, R: FAILURE:BEHAVIOR_TREE_NODE_FAILURE");
+
+  // child success with warning
+  runFixture(NodeStatus::SUCCESS, 13, NodeStatus::FAILURE, 13,
+             "Ch: SUCCESS:13, R: FAILURE:13");
+
+  // child failure with OK
+  runFixture(NodeStatus::FAILURE, BtErrorCodes::OK, NodeStatus::FAILURE,
+             BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE,
+             "Ch: FAILURE:OK, R: FAILURE:BEHAVIOR_TREE_NODE_FAILURE");
+
+  // child failure with error
+  runFixture(NodeStatus::FAILURE, 154, NodeStatus::FAILURE, 154,
+             "Ch: FAILURE:154, R: FAILURE:154");
+}
+
+TEST_F(GeneralStatusDecoratorTest, ForceSuccessNode)
+{
+  createRoot_ = [&]() {
+    root_ = std::make_unique<BT::ForceSuccessNode>("ForceSuccessNode");
+  };
+
+  // child success with OK
+  runFixture(NodeStatus::SUCCESS, BtErrorCodes::OK, NodeStatus::SUCCESS, BtErrorCodes::OK,
+             "Ch: SUCCESS:OK, R: SUCCESS:OK");
+
+  // child success with warning
+  runFixture(NodeStatus::SUCCESS, 13, NodeStatus::SUCCESS, BtErrorCodes::OK,
+             "Ch: SUCCESS:13, R: SUCCESS:OK");
+
+  // child failure with OK
+  runFixture(NodeStatus::FAILURE, BtErrorCodes::OK, NodeStatus::SUCCESS, BtErrorCodes::OK,
+             "Ch: FAILURE:OK, R: SUCCESS:OK");
+
+  // child failure with error
+  runFixture(NodeStatus::FAILURE, 154, NodeStatus::SUCCESS, BtErrorCodes::OK,
+             "Ch: FAILURE:154, R: SUCCESS:OK");
+}
+
+TEST_F(GeneralStatusDecoratorTest, Inverter)
+{
+  createRoot_ = [&]() { root_ = std::make_unique<BT::InverterNode>("inverter"); };
+
+  // child success with OK
+  runFixture(NodeStatus::SUCCESS, BtErrorCodes::OK, NodeStatus::FAILURE,
+             BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE,
+             "Ch: SUCCESS:OK, R: FAILURE:BEHAVIOR_TREE_NODE_FAILURE");
+
+  // child success with warning
+  runFixture(NodeStatus::SUCCESS, 13, NodeStatus::FAILURE, 13,
+             "Ch: SUCCESS:13, R: FAILURE:13");
+
+  // child failure with OK
+  runFixture(NodeStatus::FAILURE, BtErrorCodes::OK, NodeStatus::SUCCESS, BtErrorCodes::OK,
+             "Ch: FAILURE:OK, R: SUCCESS:OK");
+
+  // child failure with error
+  runFixture(NodeStatus::FAILURE, 154, NodeStatus::SUCCESS, BtErrorCodes::OK,
+             "Ch: FAILURE:154, R: SUCCESS:OK");
+}
+
+TEST_F(GeneralStatusDecoratorTest, KeepRunningUntilFailureNode)
+{
+  createRoot_ = [&]() {
+    root_ = std::make_unique<BT::KeepRunningUntilFailureNode>("KeepRunningUntilFailureNod"
+                                                              "e");
+  };
+
+  // child failure with OK
+  runFixture(NodeStatus::FAILURE, BtErrorCodes::OK, NodeStatus::FAILURE,
+             BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE,
+             "Ch: FAILURE:OK, R: FAILURE:BEHAVIOR_TREE_NODE_FAILURE");
+
+  // child failure with error
+  runFixture(NodeStatus::FAILURE, 154, NodeStatus::FAILURE, 154,
+             "Ch: FAILURE:154, R: FAILURE:154");
+
+  /* Repeat once and fail */
+  EnumType firstCode = 123;
+  EnumType secondCode = 321;
+  createRoot_();
+  initialize(NodeStatus::SUCCESS, firstCode);
+  // first run - RUNNING
+  BT::NodeStatus state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node not running (1A)";
+  // first run - SUCCESS
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node not running (1B)";
+  // second run - RUNNING
+  action_->setExpectedResult(NodeStatus::FAILURE);
+  action_->setExpectedCode(secondCode);
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node not running (2A)";
+  // third run - FAILURE
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::FAILURE) << "Root node not finished (2B)";
+
+  // Check results - repeat node should contain executed children's status and the last children contains failure.
+  const auto& status = root_->getGeneralStatus();
+  ASSERT_TRUE(status.has_value()) << "Root node status not set";
+  EXPECT_EQ(status.value().status_code_, secondCode) << "Root node status mismatch";
+
+  ASSERT_EQ(status.value().underlying_status_messages_.size(), 1U) << "Root node do not "
+                                                                      "store executed "
+                                                                      "children status.";
+  const auto& first_child_status = status.value().underlying_status_messages_.at(0);
+  EXPECT_EQ(first_child_status->status_code_, firstCode) << "First child status mismatch";
+
+  EXPECT_EQ(action_->status(), NodeStatus::IDLE);
+  const auto& second_child_status = action_->getGeneralStatus();
+  ASSERT_TRUE(second_child_status.has_value()) << "Child node status not set";
+  EXPECT_EQ(second_child_status.value().status_code_, secondCode) << "Child node "
+                                                                     "status "
+                                                                     "mismatch";
+}
+
+TEST_F(GeneralStatusDecoratorTest, RepeatNode)
+{
+  createRoot_ = [&]() { root_ = std::make_unique<BT::RepeatNode>("RepeatNode", 1); };
+  runDefaultFixtures();
+
+  /* Repeat once and fail */
+  EnumType firstCode = 123;
+  EnumType secondCode = 321;
+  root_ = std::make_unique<BT::RepeatNode>("RepeatNode", 3);
+  initialize(NodeStatus::SUCCESS, firstCode);
+  // first run - RUNNING
+  BT::NodeStatus state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node not running (1)";
+  // second run - SUCCESS & RUNNING
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node not running (2)";
+  // third run - FAILURE
+  action_->setExpectedResult(NodeStatus::FAILURE);
+  action_->setExpectedCode(secondCode);
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::FAILURE) << "Root node not finished (3)";
+
+  // Check results - repeat node should contain executed children's status and the last children contains failure.
+  const auto& status = root_->getGeneralStatus();
+  ASSERT_TRUE(status.has_value()) << "Root node status not set";
+  EXPECT_EQ(status.value().status_code_, secondCode) << "Root node status mismatch";
+
+  ASSERT_EQ(status.value().underlying_status_messages_.size(), 1U) << "Root node do not "
+                                                                      "store executed "
+                                                                      "children status.";
+  const auto& first_child_status = status.value().underlying_status_messages_.at(0);
+  EXPECT_EQ(first_child_status->status_code_, firstCode) << "First child status mismatch";
+
+  EXPECT_EQ(action_->status(), NodeStatus::IDLE);
+  const auto& second_child_status = action_->getGeneralStatus();
+  ASSERT_TRUE(second_child_status.has_value()) << "Child node status not set";
+  EXPECT_EQ(second_child_status.value().status_code_, secondCode) << "Child node "
+                                                                     "status "
+                                                                     "mismatch";
+}
+
+TEST_F(GeneralStatusDecoratorTest, RetryNode)
+{
+  createRoot_ = [&]() { root_ = std::make_unique<BT::RetryNode>("RetryNode", 1); };
+  runDefaultFixtures();
+
+  /* Fail once and retry */
+  EnumType firstCode = 123;
+  EnumType secondCode = 321;
+  root_ = std::make_unique<BT::RetryNode>("RetryNode", 3);
+  initialize(NodeStatus::FAILURE, firstCode);
+  // first run - RUNNING
+  BT::NodeStatus state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node not running (1)";
+  // second run - FAILURE & RUNNING
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node not running (2)";
+  // third run - SUCCESS
+  action_->setExpectedResult(NodeStatus::SUCCESS);
+  action_->setExpectedCode(secondCode);
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::SUCCESS) << "Root node not finished (3)";
+
+  // Check results - RetryNode should contain executed children's status and the last children contains second code (not propagated).
+  const auto& status = root_->getGeneralStatus();
+  ASSERT_TRUE(status.has_value()) << "Root node status not set";
+  EXPECT_EQ(status.value().status_code_, BtErrorCodes::OK) << "Root node status mismatch";
+
+  ASSERT_EQ(status.value().underlying_status_messages_.size(), 1U) << "Root node do not "
+                                                                      "store executed "
+                                                                      "children status.";
+  const auto& first_child_status = status.value().underlying_status_messages_.at(0);
+  EXPECT_EQ(first_child_status->status_code_, firstCode) << "First child status mismatch";
+
+  EXPECT_EQ(action_->status(), NodeStatus::IDLE);
+  const auto& second_child_status = action_->getGeneralStatus();
+  ASSERT_TRUE(second_child_status.has_value()) << "Child node status not set";
+  EXPECT_EQ(second_child_status.value().status_code_, secondCode) << "Child node "
+                                                                     "status "
+                                                                     "mismatch";
+}
+
+TEST_F(GeneralStatusDecoratorTest, SubtreeNode)
+{
+  createRoot_ = [&]() { root_ = std::make_unique<BT::SubtreeNode>("SubtreeNode"); };
+  runDefaultFixtures();
+}
+
+TEST_F(GeneralStatusDecoratorTest, TimeoutNode)
+{
+  createRoot_ = [&]() { root_ = std::make_unique<BT::TimeoutNode<>>("TimeoutNode", 5); };
+
+  runDefaultFixtures();
+
+  // timeout
+  createRoot_();
+  initialize(NodeStatus::SUCCESS, 112);
+  BT::NodeStatus state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::RUNNING) << "Root node finished too soon";
+  ASSERT_FALSE(root_->getGeneralStatus().has_value()) << "Root node status already set";
+
+  // second tick - timeout
+  std::this_thread::sleep_for(std::chrono::milliseconds(defaultDelayMs_));
+  state = root_->executeTick();
+  EXPECT_EQ(state, NodeStatus::FAILURE) << "Root node not finished";
+  const auto& status = root_->getGeneralStatus();
+  ASSERT_TRUE(status.has_value()) << "Root node status not set";
+  EXPECT_EQ(status.value().status_code_, BtErrorCodes::BEHAVIOR_TREE_NODE_FAILURE) << "Ro"
+                                                                                      "ot"
+                                                                                      " n"
+                                                                                      "od"
+                                                                                      "e "
+                                                                                      "st"
+                                                                                      "at"
+                                                                                      "us"
+                                                                                      " m"
+                                                                                      "is"
+                                                                                      "ma"
+                                                                                      "tc"
+                                                                                      "h";
+
+  EXPECT_EQ(action_->status(), NodeStatus::IDLE);
+  const auto& child_status = action_->getGeneralStatus();
+  ASSERT_FALSE(child_status.has_value()) << "Child node status is set";
+}

--- a/tests/include/status_action_test_node.h
+++ b/tests/include/status_action_test_node.h
@@ -1,0 +1,26 @@
+#ifndef STATUS_ACTION_TEST_NODE_H
+#define STATUS_ACTION_TEST_NODE_H
+
+#include "behaviortree_cpp_v3/action_node.h"
+
+class StatusActionTestNode : public BT::ActionNodeBase
+{
+public:
+  StatusActionTestNode(const std::string& name);
+  BT::NodeStatus tick() override;
+  void setExpectedResult(BT::NodeStatus res);
+  void setExpectedCode(BT::general_status::EnumType code);
+  BT::general_status::EnumType getExpectedCode() const;
+  int tickCount() const;
+  void resetTicks();
+  void halt() override;
+
+private:
+  BT::NodeStatus expected_result_;
+  BT::general_status::EnumType expected_code_;
+  int tick_count_;
+};
+
+// Declare your class or functions here
+
+#endif   // STATUS_ACTION_TEST_NODE_H

--- a/tests/src/status_action_test_node.cpp
+++ b/tests/src/status_action_test_node.cpp
@@ -9,8 +9,8 @@ StatusActionTestNode::StatusActionTestNode(const std::string& name) :
   setGeneralStatusUpdateFunction(
       [&](TreeNode& tree_node, BT::NodeStatus node_status,
           BT::Optional<BT::general_status::GeneralStatus>& status) {
-        status = BT::general_status::GeneralStatus();
-        status->status_code_ = expected_code_;
+        TreeNode::defaultGeneralStatusUpdateCallback(*this, node_status, status);
+        status->status_code_ = expected_code_; // override the default status code
       });
 }
 

--- a/tests/src/status_action_test_node.cpp
+++ b/tests/src/status_action_test_node.cpp
@@ -1,0 +1,55 @@
+#include "status_action_test_node.h"
+
+StatusActionTestNode::StatusActionTestNode(const std::string& name) :
+  BT::ActionNodeBase(name, {})
+{
+  tick_count_ = 0;
+  expected_result_ = BT::NodeStatus::IDLE;
+  expected_code_ = BT::general_status::BtErrorCodes::OK;
+  setGeneralStatusUpdateFunction(
+      [&](TreeNode& tree_node, BT::NodeStatus node_status,
+          BT::Optional<BT::general_status::GeneralStatus>& status) {
+        status = BT::general_status::GeneralStatus();
+        status->status_code_ = expected_code_;
+      });
+}
+
+int StatusActionTestNode::tickCount() const
+{
+  return tick_count_;
+}
+
+void StatusActionTestNode::resetTicks()
+{
+  tick_count_ = 0;
+}
+
+void StatusActionTestNode::halt()
+{
+  resetTicks();
+}
+
+BT::NodeStatus StatusActionTestNode::tick()
+{
+  if (status() == BT::NodeStatus::IDLE)
+    resetTicks();
+  tick_count_++;
+  if (tick_count_ == 1)
+    return BT::NodeStatus::RUNNING;
+  return expected_result_;
+}
+
+void StatusActionTestNode::setExpectedResult(BT::NodeStatus res)
+{
+  expected_result_ = res;
+}
+
+void StatusActionTestNode::setExpectedCode(BT::general_status::EnumType code)
+{
+  expected_code_ = code;
+}
+
+BT::general_status::EnumType StatusActionTestNode::getExpectedCode() const
+{
+  return expected_code_;
+}


### PR DESCRIPTION
Introduce status propagation for control nodes. All nodes have additional unit test (except ManualNode and ConsumeQueue)
Add reset mechanism of the general status so it is cleared when rerunning the same node (i.e. repeated). 
Tree status generation automatically cleans the tree from remaining states. 
